### PR TITLE
NLog is configured and setup on the API project so we can monitor logs in production now. Closes #3

### DIFF
--- a/PS.UI.Xamarin/PS.UI.Xamarin.Android/PS.UI.Xamarin.Android.csproj
+++ b/PS.UI.Xamarin/PS.UI.Xamarin.Android/PS.UI.Xamarin.Android.csproj
@@ -37,6 +37,7 @@
     <EnableLLVM>false</EnableLLVM>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>false</BundleAssemblies>
+    <MandroidI18n />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/PS.Web.API/PS.Web.API.csproj
+++ b/PS.Web.API/PS.Web.API.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 

--- a/PS.Web.API/nlog.config
+++ b/PS.Web.API/nlog.config
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      internalLogLevel="Info"
+      internalLogFile="c:\temp\internal-nlog.txt">
+
+  <!-- enable asp.net core layout renderers -->
+  <extensions>
+    <add assembly="NLog.Web.AspNetCore"/>
+  </extensions>
+  
+  <variable name="logDirectory" value="Logs/${shortdate}" />
+  
+  <!-- the targets to write to -->
+  <targets>
+    <!-- write logs to file  -->
+    <target name="allfile" xsi:type="File"
+            fileName="${logDirectory}/allLogs.txt"
+            layout="${longdate}|${event-properties:item=EventId_Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}" /> 
+  </targets>
+
+  <!-- rules to map from logger name to target -->
+  <rules>
+    <!--All logs, including from Microsoft-->
+    <logger name="*" minlevel="Trace" writeTo="allfile" />
+  </rules>
+</nlog>


### PR DESCRIPTION
This allows us to view log files in production
closes #3 